### PR TITLE
fix: include TLA+ tools in docker image

### DIFF
--- a/.devcontainer/.bash_aliases
+++ b/.devcontainer/.bash_aliases
@@ -1,3 +1,3 @@
-alias tlc="java -jar $TLA_TOOLS_JAR"
-alias pcal-trans="java -cp $TLA_TOOLS_JAR pcal.trans"
-alias tla2tex="java -cp $TLA_TOOLS_JAR tla2tex.TeX"
+alias tlc="java tlc2.TLC"
+alias pcal-trans="java pcal.trans"
+alias tla2tex="java tla2tex.TeX"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,14 @@ RUN mkdir -p /workdir/zephyr-model-based-testing
 RUN chown user:user /workdir
 RUN chsh -s /bin/bash user
 
-USER user
+# Install most recent version of the TLA+ tools and Community Modules
+ARG TLA_TOOLS_JAR_URL=https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+ARG TLA_COMMUNITY_MODULES_JAR_URL=https://github.com/tlaplus/CommunityModules/releases/latest/download/CommunityModules-deps.jar
+RUN wget -O /usr/share/java/tla2tools.jar ${TLA_TOOLS_JAR_URL} && \
+    wget -O /usr/share/java/CommunityModules-deps.jar ${TLA_COMMUNITY_MODULES_JAR_URL}
 
-ENV TLA_TOOLS_JAR=/home/user/tla2tools.jar
+# Add TLA+ tools, community modules and our TLA+ library to the Java classpath
+ENV CLASSPATH=/usr/share/java/tla2tools.jar:/usr/share/java/CommunityModules-deps.jar:/workdir/zephyr-model-based-testing/specs/lib
+
+USER user
 COPY .bash_aliases /home/user/.bash_aliases

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,6 +15,5 @@
       ]
     }
   },
-  "postCreateCommand": "bash /workdir/zephyr-model-based-testing/.devcontainer/setup.sh",
-  "postStartCommand": "bash /workdir/zephyr-model-based-testing/.devcontainer/post_start.sh"
+  "postCreateCommand": "bash /workdir/zephyr-model-based-testing/.devcontainer/setup.sh"
 }

--- a/.devcontainer/post_start.sh
+++ b/.devcontainer/post_start.sh
@@ -1,6 +1,0 @@
-#! /bin/bash
-# fixing the symlink for tla2tools if it is broken. This can occur when the
-# vscode tla extension is updated
-if  file /home/user/tla2tools.jar | grep broken 2>&1>/dev/null; then
-  ln -sf $(find /home/user/ -type f -name "tla2tools.jar" -print -quit) /home/user/tla2tools.jar;
-fi

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,9 +1,8 @@
-while [ "$(find /home/user -type f -name 'tla2tools.jar')" == "" ]; do
-	sleep 3;
-done
+#!/bin/bash
 
+# Change owner of mounted workspace to user
 sudo chown user:user /workdir
 
-ln -s $(find /home/user/ -type f -name 'tla2tools.jar' -print -quit 2>/dev/null) /home/user/tla2tools.jar
-cd /workdir/zephyr-mmodel-based-testing
+# Install pre-commit hooks in mounted repository
+cd /workdir/zephyr-model-based-testing
 pre-commit install


### PR DESCRIPTION
Instead of using the TLA+ tools included in the TLA+ VSCode extension, download the tools into the docker image. This allows the Docker image to be used without VSCode.